### PR TITLE
Noinstall option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+
+# Vagrant #
+###########
+.vagrant
+*.box
+
+*.crt
+*.key
+cluster.yml
+agent.yml
+node_mapping.yml

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ git clone https://github.com/lukemarsden/unofficial-flocker-tools
 cd unofficial-flocker-tools
 mv cluster.yml.sample cluster.yml
 vim cluster.yml # customize for your cluster
+./install.py cluster.yml
 ./deploy.py cluster.yml
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,22 @@ Prerequisites:
 ```
 git clone https://github.com/lukemarsden/unofficial-flocker-tools
 cd unofficial-flocker-tools
-mv cluster.yml.sample cluster.yml
+mv cluster.yml.ebs.sample cluster.yml
 vim cluster.yml # customize for your cluster
 ./install.py cluster.yml
 ./deploy.py cluster.yml
 ```
+
+## cluster.yml
+
+There are 3 example configuration files that correspond to the backend Flocker will use - base your cluster.yml on one of these files:
+
+ * [AWS EBS](cluster.yml.ebs.sample)
+ * [Opentstack Cinder](cluster.yml.openstack.sample)
+ * [AWS EBS](cluster.yml.zfs.sample)
+
+## notes
+
+ * You need to ensure that machines can be SSH'd into as root
+ * You need a private key to access the machines - you can configure this in the `private_key_path` of cluster.yml
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There are 3 example configuration files that correspond to the backend Flocker w
 
  * [AWS EBS](cluster.yml.ebs.sample)
  * [Opentstack Cinder](cluster.yml.openstack.sample)
- * [AWS EBS](cluster.yml.zfs.sample)
+ * [ZFS](cluster.yml.zfs.sample)
 
 ## notes
 

--- a/cluster.yml.ebs.sample
+++ b/cluster.yml.ebs.sample
@@ -5,17 +5,16 @@ agent_nodes:
 control_node: dns.name.for.control.node # or IP address (but you must always connect via TLS to the given name here)
 users:
  - user1
-os: XXX # ubuntu-14.04 or centos7
+os: XXX # ubuntu or centos
+private_key_path: XXX # the key used to SSH as root onto the nodes
 agent_config:
   version: 1
   control-service:
      hostname: XXX # control_node should get substituted in here
      port: 4524
   dataset:
-     backend: XXX
-     # other backend settings (these vary per backend, this is example of openstack):
-     username: XXX
-     api_key: XXX
-     region: XXX
-     auth_url: XXX
-     auth_plugin: XXX
+    backend: "aws"
+    region: "us-west-1"
+    zone: "us-west-1a"
+    access_key_id: "foo"
+    secret_access_key: "bar"

--- a/cluster.yml.openstack.sample
+++ b/cluster.yml.openstack.sample
@@ -1,0 +1,21 @@
+cluster_name: name 
+agent_nodes:
+ - 1.2.3.4
+ - 1.2.3.5
+control_node: dns.name.for.control.node # or IP address (but you must always connect via TLS to the given name here)
+users:
+ - user1
+os: XXX # ubuntu or centos
+private_key_path: XXX # the key used to SSH as root onto the nodes
+agent_config:
+  version: 1
+  control-service:
+    hostname: XXX # control_node should get substituted in here
+    port: 4524
+  dataset:
+    backend: "openstack"
+    region: "LON"
+    auth_plugin: "rackspace"
+    username: "joe.bloggs.rackspace"
+    api_key: "aaa-bbb-ccc-ddd"
+    auth_url: "https://lon.identity.api.rackspacecloud.com/v2.0"

--- a/cluster.yml.zfs.sample
+++ b/cluster.yml.zfs.sample
@@ -1,0 +1,16 @@
+cluster_name: name 
+agent_nodes:
+ - 1.2.3.4
+ - 1.2.3.5
+control_node: dns.name.for.control.node # or IP address (but you must always connect via TLS to the given name here)
+users:
+ - user1
+os: XXX # ubuntu or centos
+private_key_path: XXX # the key used to SSH as root onto the nodes
+agent_config:
+  version: 1
+  control-service:
+     hostname: XXX # control_node should get substituted in here
+     port: 4524
+  dataset:
+     backend: "zfs"

--- a/deploy.py
+++ b/deploy.py
@@ -55,18 +55,11 @@ if __name__ == "__main__":
     for node, uuid in node_mapping.iteritems():
         if c.config["os"] == "ubuntu":
             c.runSSH(node, """apt-get -y install apt-transport-https software-properties-common
-add-apt-repository -y ppa:james-page/docker
-add-apt-repository -y 'deb https://clusterhq-archive.s3.amazonaws.com/ubuntu-testing/14.04/$(ARCH) /'
-apt-get update
-apt-get -y --force-yes install clusterhq-flocker-node
 service flocker-container-agent restart
 service flocker-dataset-agent restart
 """)
         elif c.config["os"] == "centos":
             c.runSSH(node, """if selinuxenabled; then setenforce 0; fi
-test -e /etc/selinux/config && sed --in-place='.preflocker' 's/^SELINUX=.*$/SELINUX=disabled/g' /etc/selinux/config
-yum install -y https://s3.amazonaws.com/clusterhq-archive/centos/clusterhq-release$(rpm -E %dist).noarch.rpm
-yum install -y clusterhq-flocker-node
 systemctl enable docker.service
 systemctl start docker.service
 """)

--- a/deploy.py
+++ b/deploy.py
@@ -27,6 +27,7 @@ if __name__ == "__main__":
     print "Uploading keys to respective nodes:"
 
     # Copy cluster cert, and control cert and key to control node.
+    c.runSSHRaw(c.config["control_node"], "mkdir -p /etc/flocker")
     c.scp("cluster.crt", c.config["control_node"], "/etc/flocker/cluster.crt")
     print " * Uploaded cluster cert to control node."
     for ext in ("crt", "key"):
@@ -45,6 +46,7 @@ if __name__ == "__main__":
 
     # Copy cluster cert, and agent cert and key to agent nodes.
     for node, uuid in node_mapping.iteritems():
+        c.runSSHRaw(node, "mkdir -p /etc/flocker")
         c.scp("cluster.crt", node, "/etc/flocker/cluster.crt")
         c.scp("agent.yml", node, "/etc/flocker/agent.yml")
         print " * Uploaded cluster cert to %s." % (node,)

--- a/install.py
+++ b/install.py
@@ -11,7 +11,7 @@ from utils import Configurator
 if __name__ == "__main__":
     c = Configurator(configFile=sys.argv[1])
     
-    for node, uuid in node_mapping.iteritems():
+    for node in c.config["agent_nodes"]:
         if c.config["os"] == "ubuntu":
             c.runSSH(node, """apt-get -y install apt-transport-https software-properties-common
 add-apt-repository -y ppa:james-page/docker

--- a/install.py
+++ b/install.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+# This script will use the correct repo to install .debs for clusterhq-flocker-node
+
+import sys
+import yaml
+
+# Usage: deploy.py cluster.yml
+from utils import Configurator
+
+if __name__ == "__main__":
+    c = Configurator(configFile=sys.argv[1])
+    
+    for node, uuid in node_mapping.iteritems():
+        if c.config["os"] == "ubuntu":
+            c.runSSH(node, """apt-get -y install apt-transport-https software-properties-common
+add-apt-repository -y ppa:james-page/docker
+add-apt-repository -y 'deb https://clusterhq-archive.s3.amazonaws.com/ubuntu-testing/14.04/$(ARCH) /'
+apt-get update
+apt-get -y --force-yes install clusterhq-flocker-node
+""")
+        elif c.config["os"] == "centos":
+            c.runSSH(node, """if selinuxenabled; then setenforce 0; fi
+test -e /etc/selinux/config && sed --in-place='.preflocker' 's/^SELINUX=.*$/SELINUX=disabled/g' /etc/selinux/config
+yum install -y https://s3.amazonaws.com/clusterhq-archive/centos/clusterhq-release$(rpm -E %dist).noarch.rpm
+yum install -y clusterhq-flocker-node
+""")
+
+    print "Installed clusterhq-flocker-node on all nodes"
+    print "To configure and deploy the cluster:"
+    print "./deploy.py cluster.yml"

--- a/utils.py
+++ b/utils.py
@@ -11,19 +11,19 @@ class Configurator(object):
         self.config["remote_server_username"] = self.config.get("remote_server_username", "root")
 
     def runSSH(self, ip, command):
-        command = 'ssh -i %s %s@%s %s' % (self.config["private_key_path"],
+        command = 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i %s %s@%s %s' % (self.config["private_key_path"],
                 self.config["remote_server_username"],
                 ip, " ".join(map(quote, ["sh", "-c", command])))
         return subprocess.check_output(command, shell=True)
 
     def runSSHRaw(self, ip, command):
-        command = 'ssh -i %s %s@%s %s' % (self.config["private_key_path"],
+        command = 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i %s %s@%s %s' % (self.config["private_key_path"],
                 self.config["remote_server_username"],
                 ip, command)
         return subprocess.check_output(command, shell=True)
 
     def runSSHPassthru(self, ip, command):
-        command = 'ssh -i %s %s@%s %s' % (self.config["private_key_path"],
+        command = 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i %s %s@%s %s' % (self.config["private_key_path"],
                 self.config["remote_server_username"],
                 ip, " ".join(map(quote, command)))
         return os.system(command)
@@ -64,7 +64,7 @@ class Configurator(object):
             private_key_path = self.config["private_key_path"]
         if remote_server_username is not None:
             remote_server_username = self.config["remote_server_username"]
-        scp = ("scp -i %(private_key_path)s %(local_path)s "
+        scp = ("scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i %(private_key_path)s %(local_path)s "
                "%(remote_server_username)s@%(external_ip)s:%(remote_path)s") % dict(
                     private_key_path=self.config["private_key_path"],
                     remote_server_username=self.config["remote_server_username"],


### PR DESCRIPTION
This PR:
- splits out `install.py` and `deploy.py` as 2 separate scripts - the user can choose which they want
- disables `StrictHostKeyChecking` for SSH and SCP connections
- adds a few sample cluster.yml files - one for each backend
- adds some notes to the README
  - need root@ access to the machine
  - can configure the private key to use
