### PR TITLE
Prototype volumes cli

### DIFF
--- a/flocker-volumes.py
+++ b/flocker-volumes.py
@@ -101,11 +101,16 @@ class List(Options):
             rows = []
 
             for (key, dataset) in configuration_map.iteritems():
-                if dataset["deleted"] and self["deleted"]:
-                    if key in state_map:
-                        status = "deleting"
+                if dataset["deleted"]:
+                    # the user has asked to see deleted datasets
+                    if self["deleted"]:
+                        if key in state_map:
+                            status = "deleting"
+                        else:
+                            status = "deleted"
+                    # we are hiding deleted datasets
                     else:
-                        status = "deleted"
+                        continue
                 else:
                     if key in state_map:
                         if state_map[key]["primary"] in nodes_map:

--- a/flocker-volumes.py
+++ b/flocker-volumes.py
@@ -95,7 +95,7 @@ class List(Options):
             # build up a table, based on which datasets are in the
             # configuration, adding data from the state as necessary
             configuration_map = dict((d["dataset_id"], d) for d in configuration_datasets)
-            state_map = dict((d["dataset_id"], d) for d in configuration_datasets)
+            state_map = dict((d["dataset_id"], d) for d in state_datasets)
             nodes_map = dict((n["uuid"], n) for n in state_nodes)
 
             rows = []


### PR DESCRIPTION
This PR has a couple of small bug fixes to the `list` command:
- the `deleted` logic meant that if the `-d` flag was not used, it showed a deleted volume as `attached`
- the `state_map` was being built from the `configuration_datasets`

With these fixes the output of `./flocker-volumes.py list` is:

```
DATASET   SIZE   METADATA   STATUS   SERVER
```

and the output of `./flocker-volumes.py list -d` is:

```
DATASET    SIZE      METADATA       STATUS    SERVER
a32e828b   100.00G   name=apples3   deleted   dee64e88 (10.169.163.196)
4c1995d8   100.00G   name=apples2   deleted   d60b9ebd (10.169.97.13)
b87001d4   100.00G   name=apples1   deleted   d60b9ebd (10.169.97.13)
3bf2fe72   100.00G   name=apples    deleted   d60b9ebd (10.169.97.13)
```
