### PR TITLE
Little fixes

### DIFF
--- a/unofficial_flocker_tools/install.py
+++ b/unofficial_flocker_tools/install.py
@@ -27,7 +27,7 @@ yum install -y clusterhq-flocker-node
 
     print "Installed clusterhq-flocker-node on all nodes"
     print "To configure and deploy the cluster:"
-    print "flocker-deploy cluster.yml"
+    print "flocker-config cluster.yml"
 
 if __name__ == "__main__":
     main()

--- a/unofficial_flocker_tools/plugin.py
+++ b/unofficial_flocker_tools/plugin.py
@@ -83,7 +83,7 @@ def main():
         if c.config["os"] == "ubuntu":
             # newer versions of docker insist on AUFS on ubuntu, probably for good reason.
             c.runSSHRaw(public_ip, "DEBIAN_FRONTEND=noninteractive "
-                                   "apt-get install -y linux-image-extra-$(uname -r)")
+                "'apt-get install -y linux-image-extra-$(uname -r)'")
 
         # start the docker service
         print "Starting the docker service on %s" % (public_ip,)

--- a/unofficial_flocker_tools/sample_files.py
+++ b/unofficial_flocker_tools/sample_files.py
@@ -9,6 +9,3 @@ def main():
         resource = resource_filename("unofficial_flocker_tools", "samples/" + filename)
         shutil.copyfile(resource, filename)
         print filename
-
-if __name__ == "__main__":
-    main()

--- a/unofficial_flocker_tools/sample_files.py
+++ b/unofficial_flocker_tools/sample_files.py
@@ -9,3 +9,6 @@ def main():
         resource = resource_filename("unofficial_flocker_tools", "samples/" + filename)
         shutil.copyfile(resource, filename)
         print filename
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A couple of fixes in this PR:
- add a `if __name__ == "__main__":` block to sample_files.py
- after running `install.py` it mentioned running `flocker-deploy` - changed to `flocker-config`
- when running `plugin.py` - it was interpreting `uname -a` on the local machine not the target machine

With these fixes - I was able to use the docs instructions to get the plugin installed and configured
