### PR TITLE
be consistent with the use of bash prompt dollar signs

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Commands:
 A tool to copy the sample configuration files into the current working directory.
 
 ```
-$ flocker-sample-files
+flocker-sample-files
 ```
 
 ## notes


### PR DESCRIPTION
Missed that the last example also had a $ bash prompt and the others didn't
