### PR TITLE
install.py checks if the backend if ZFS and if yes it will install ZFS

### DIFF
--- a/unofficial_flocker_tools/install.py
+++ b/unofficial_flocker_tools/install.py
@@ -25,6 +25,63 @@ yum install -y https://s3.amazonaws.com/clusterhq-archive/centos/clusterhq-relea
 yum install -y clusterhq-flocker-node
 """)
 
+    # if the dataset.backend is ZFS then install ZFS and mount a flocker pool
+    # then create and distribute SSH keys amoungst the nodes
+    if c.config["agent_config"]["dataset"]["backend"] == "zfs":
+        # CentOS ZFS installation requires a restart
+        # XXX todo - find out a way to handle a restart mid-script
+        if c.config["os"] == "centos":
+            print >> sys.stderr, (
+                "Auto-install of ZFS on centos is "
+                "not currently supported")
+            sys.exit(1)
+
+        for node in c.config["agent_nodes"]:
+            node_public_ip = node["public"]
+            if c.config["os"] == "ubuntu":
+                c.runSSH(node_public_ip, """echo installing-zfs
+add-apt-repository -y ppa:zfs-native/stable
+apt-get update
+apt-get -y --force-yes install libc6-dev zfsutils
+mkdir -p /var/opt/flocker
+truncate --size 10G /var/opt/flocker/pool-vdev
+zpool create flocker /var/opt/flocker/pool-vdev
+""")
+
+        """
+        Loop over each node and generate SSH keys
+        Then get the public key so we can distribute it to other nodes
+        """
+        for node in c.config["agent_nodes"]:
+            node_public_ip = node["public"]
+            print "Generating SSH Keys for %s" % (node_public_ip,)
+            publicKey = c.runSSH(node_public_ip, """cat <<EOF > /tmp/genkeys.sh
+#!/bin/bash
+ssh-keygen -q -f /root/.ssh/id_rsa -N ""
+EOF
+bash /tmp/genkeys.sh
+cat /root/.ssh/id_rsa.pub
+rm /tmp/genkeys.sh
+""")
+
+            publicKey = publicKey.rstrip('\n')
+            """
+            Now we have the public key for the node we loop over all the other
+            nodes and append it to /root/.ssh/authorized_keys
+            """
+            for othernode in c.config["agent_nodes"]:
+                othernode_public_ip = othernode["public"]
+                if othernode_public_ip != node_public_ip:
+                    print "Copying %s key -> %s" % (
+                        node_public_ip, othernode_public_ip,)
+                    c.runSSH(othernode_public_ip, """cat <<EOF > /tmp/uploadkey.sh
+#!/bin/bash
+echo "%s" >> /root/.ssh/authorized_keys
+EOF
+bash /tmp/uploadkey.sh
+rm /tmp/uploadkey.sh
+""" % (publicKey,))
+
     print "Installed clusterhq-flocker-node on all nodes"
     print "To configure and deploy the cluster:"
     print "flocker-config cluster.yml"


### PR DESCRIPTION
on each agent node and then generate SSH keys for each node before distributing those keys to all other nodes

It uses a trick where it will write a script, execute the script and then remove the script.  This was the only way I could get the `ssh-keygen` command to work non-interactively and also to append the public keys to `/root/.ssh/authorized_keys`
