### PR TITLE
Review: Swarm integration

### DIFF
--- a/unofficial_flocker_tools/config.py
+++ b/unofficial_flocker_tools/config.py
@@ -5,7 +5,6 @@
 
 import sys
 import yaml
-import subprocess
 import time
 from twisted.internet.task import react
 from twisted.internet.defer import inlineCallbacks, gatherResults

--- a/unofficial_flocker_tools/config.py
+++ b/unofficial_flocker_tools/config.py
@@ -5,6 +5,8 @@
 
 import sys
 import yaml
+import subprocess
+import time
 from twisted.internet.task import react
 from twisted.internet.defer import inlineCallbacks, gatherResults
 
@@ -16,7 +18,7 @@ def report_completion(result, public_ip, message=""):
     return result
 
 @inlineCallbacks
-def main(reactor, args):
+def main(reactor, *args):
     c = Configurator(configFile=sys.argv[1])
     c.run("flocker-ca initialize %s" % (c.config["cluster_name"],))
     log("Initialized cluster CA.")
@@ -142,6 +144,36 @@ docker run --restart=always -d --net=host -v /etc/flocker:/etc/flocker --volumes
     deferreds.append(d)
 
     yield gatherResults(deferreds)
+
+    if c.config["os"] == "ubuntu":
+        if len(sys.argv) > 2:
+            if sys.argv[2] == "--swarm":
+                clusterid = c.runSSH(c.config["control_node"], """
+docker run swarm create""").strip()
+                log("Created Swarm ID")
+                for node in c.config["agent_nodes"]:
+                    d = c.runSSHAsync(node['public'], """
+service docker stop
+docker daemon -H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375 >> /tmp/dockerlogs 2>&1 &
+""")
+                    # Let daemon come up
+                    time.sleep(3)
+                    d = c.runSSHAsync(node['public'], """
+docker run -d swarm join --addr=%s:2375 token://%s
+""" % (node['private'], clusterid))
+                    log("Started Swarm Agent for %s" % node['public'])
+
+                    deferreds.append(d)
+
+                d = c.runSSHAsync(c.config["control_node"], """
+docker run -d -p 2357:2375 swarm manage token://%s
+""" % clusterid)
+                log("Started Swarm Master")
+
+            deferreds.append(d)
+
+        yield gatherResults(deferreds)
+        log("Swarm Master is at tcp://%s:2357" % c.config["control_node"])
 
 def _main():
     react(main, sys.argv[1:])

--- a/unofficial_flocker_tools/terraform_templates/aws.tf
+++ b/unofficial_flocker_tools/terraform_templates/aws.tf
@@ -80,6 +80,20 @@ resource "aws_security_group" "cluster_security_group" {
       protocol = "tcp"
       self = true
   }
+  # swarm
+  ingress {
+      from_port = 2375
+      to_port = 2375
+      protocol = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+  # swarm
+  ingress {
+      from_port = 2357
+      to_port = 2357
+      protocol = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
   # allow outbound traffic
   egress {
       from_port = 0


### PR DESCRIPTION
Looking to review this, few things
- This integrates installing Swarm with the `--swarm` flag to `uft-flocker-config` script
- The integration only works with swarm and ubuntu
- The integration used default ports `2375` for swarm agents and `2357` for swarm master. Should this be configurable? What about TLS?
- This restarts the docker daemon within a UFT cluster to listen on unix socket and external port, should we edit the `docker.service` file (managed by systemd) instead?
- needs to be tested with one test.
