### PR TITLE
gather flocker diagnostics fromm all nodes in the uft cluster

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
             "flocker-volumes = unofficial_flocker_tools.flocker_volumes:_main", # async
             "flocker-get-nodes = unofficial_flocker_tools.get_nodes:main",
             "flocker-destroy-nodes = unofficial_flocker_tools.destroy_nodes:main",
+            "flocker-get-diagnostics = unofficial_flocker_tools.diagnostics:_main", #async
         ],
     },
     version="0.5",

--- a/unofficial_flocker_tools/diagnostics.py
+++ b/unofficial_flocker_tools/diagnostics.py
@@ -1,5 +1,4 @@
 import sys
-import yaml
 import time
 from twisted.internet.task import react
 from twisted.internet.defer import inlineCallbacks, gatherResults

--- a/unofficial_flocker_tools/diagnostics.py
+++ b/unofficial_flocker_tools/diagnostics.py
@@ -18,10 +18,10 @@ def main(reactor, *args):
     deferreds = []
     log("Running Flocker-diagnostics on agent nodes.")
     for node in c.config["agent_nodes"]:
-        d = c.runSSHAsync(node["public"], "rm -rf /tmp/diagnoistics; mkdir /tmp/diagnoistics; cd /tmp/diagnoistics; flocker-diagnostics")
+        d = c.runSSHAsync(node["public"], "rm -rf /tmp/diagnostics; mkdir /tmp/diagnostics; cd /tmp/diagnostics; flocker-diagnostics")
         d.addCallback(report_completion, public_ip=node["public"], message=" * Ran diagnostics on agent node.")
         deferreds.append(d)
-    d = c.runSSHAsync(c.config["control_node"], "rm -rf /tmp/diagnoistics; mkdir /tmp/diagnoistics; cd /tmp/diagnoistics; flocker-diagnostics")
+    d = c.runSSHAsync(c.config["control_node"], "rm -rf /tmp/diagnostics; mkdir /tmp/diagnostics; cd /tmp/diagnostics; flocker-diagnostics")
     d.addCallback(report_completion, public_ip=c.config["control_node"], message=" * Ran diagnostics on control node.")
     deferreds.append(d)
     yield gatherResults(deferreds)
@@ -33,10 +33,10 @@ def main(reactor, *args):
     deferreds = []
     log("Gathering Flocker-diagnostics on agent nodes.")
     for node in c.config["agent_nodes"]:
-        d = c.scp("./", node["public"], "/tmp/diagnoistics/clusterhq_flocker_logs_*.tar", async=True, reverse=True)
+        d = c.scp("./", node["public"], "/tmp/diagnostics/clusterhq_flocker_logs_*.tar", async=True, reverse=True)
         d.addCallback(report_completion, public_ip=node["public"], message=" * Gathering diagnostics on agent node.")
         deferreds.append(d)
-    d =  c.scp("./", c.config["control_node"], "/tmp/diagnoistics/clusterhq_flocker_logs_*.tar", async=True, reverse=True)
+    d =  c.scp("./", c.config["control_node"], "/tmp/diagnostics/clusterhq_flocker_logs_*.tar", async=True, reverse=True)
     d.addCallback(report_completion, public_ip=c.config["control_node"], message=" * Gathering diagnostics on control node.")
     deferreds.append(d)
     yield gatherResults(deferreds)

--- a/unofficial_flocker_tools/diagnostics.py
+++ b/unofficial_flocker_tools/diagnostics.py
@@ -1,0 +1,49 @@
+import sys
+import yaml
+import time
+from twisted.internet.task import react
+from twisted.internet.defer import inlineCallbacks, gatherResults
+
+# Usage: diagnostics.py cluster.yml
+from utils import Configurator, log
+
+def report_completion(result, public_ip, message=""):
+    log(message, public_ip)
+    return result
+
+@inlineCallbacks
+def main(reactor, *args):
+    c = Configurator(configFile=sys.argv[1])
+
+    # Run flocker-diagnostics 
+    deferreds = []
+    log("Running Flocker-diagnostics on agent nodes.")
+    for node in c.config["agent_nodes"]:
+        d = c.runSSHAsync(node["public"], "rm -rf /tmp/diagnoistics; mkdir /tmp/diagnoistics; cd /tmp/diagnoistics; flocker-diagnostics")
+        d.addCallback(report_completion, public_ip=node["public"], message=" * Ran diagnostics on agent node.")
+        deferreds.append(d)
+    d = c.runSSHAsync(c.config["control_node"], "rm -rf /tmp/diagnoistics; mkdir /tmp/diagnoistics; cd /tmp/diagnoistics; flocker-diagnostics")
+    d.addCallback(report_completion, public_ip=c.config["control_node"], message=" * Ran diagnostics on control node.")
+    deferreds.append(d)
+    yield gatherResults(deferreds)
+
+    # Let flocker diagnostics run
+    time.sleep(5)
+
+    # Gather flocker-diagnostics 
+    deferreds = []
+    log("Gathering Flocker-diagnostics on agent nodes.")
+    for node in c.config["agent_nodes"]:
+        d = c.scp("./", node["public"], "/tmp/diagnoistics/clusterhq_flocker_logs_*.tar", async=True, reverse=True)
+        d.addCallback(report_completion, public_ip=node["public"], message=" * Gathering diagnostics on agent node.")
+        deferreds.append(d)
+    d =  c.scp("./", c.config["control_node"], "/tmp/diagnoistics/clusterhq_flocker_logs_*.tar", async=True, reverse=True)
+    d.addCallback(report_completion, public_ip=c.config["control_node"], message=" * Gathering diagnostics on control node.")
+    deferreds.append(d)
+    yield gatherResults(deferreds)
+
+def _main():
+    react(main, sys.argv[1:])
+
+if __name__ == "__main__":
+    _main()

--- a/unofficial_flocker_tools/utils.py
+++ b/unofficial_flocker_tools/utils.py
@@ -211,19 +211,27 @@ class Configurator(object):
 
     def scp(self, local_path, external_ip, remote_path,
             private_key_path=None, remote_server_username=None, async=False,
-            retry_with_timeout=600):
+            retry_with_timeout=600, reverse=False):
         if retry_with_timeout and not async:
             raise UsageError("Can't retry_with_timeout if not async")
         if private_key_path is not None:
             private_key_path = self.config["private_key_path"]
         if remote_server_username is not None:
             remote_server_username = self.config["remote_server_username"]
-        scp = ("scp -o LogLevel=error -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i %(private_key_path)s %(local_path)s "
-               "%(remote_server_username)s@%(external_ip)s:%(remote_path)s") % dict(
-                    private_key_path=self.config["private_key_path"],
-                    remote_server_username=self.config["remote_server_username"],
-                    external_ip=external_ip, remote_path=remote_path,
-                    local_path=local_path)
+        if reverse:
+            scp = ("scp -o LogLevel=error -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i %(private_key_path)s "
+                   "%(remote_server_username)s@%(external_ip)s:%(remote_path)s %(local_path)s") % dict(
+                        private_key_path=self.config["private_key_path"],
+                        remote_server_username=self.config["remote_server_username"],
+                        external_ip=external_ip, remote_path=remote_path,
+                        local_path=local_path)
+        else:
+            scp = ("scp -o LogLevel=error -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i %(private_key_path)s %(local_path)s "
+                   "%(remote_server_username)s@%(external_ip)s:%(remote_path)s") % dict(
+                        private_key_path=self.config["private_key_path"],
+                        remote_server_username=self.config["remote_server_username"],
+                        external_ip=external_ip, remote_path=remote_path,
+                        local_path=local_path)
         if async:
             verbose_log("scp async:", scp)
             if retry_with_timeout is not None:


### PR DESCRIPTION
Debugging UFT clusters with flocker diagnostics is helpful, but retrieving them to your local machine is tough. This aims to automates gathering flocker diagnostics from all nodes in a uft cluster or as definied in a uft-style `cluster.yml`

```
uft-flocker-get-diagnostics cluster.yml
Running Flocker-diagnostics on agent nodes.
 * Ran diagnostics on control node. ec2-54-183-210-219.us-west-1.compute.amazonaws.com
 * Ran diagnostics on agent node. 54.183.97.70
 * Ran diagnostics on agent node. 54.183.98.196
Gathering Flocker-diagnostics on agent nodes.
 * Gathering diagnostics on control node. ec2-54-183-210-219.us-west-1.compute.amazonaws.com
 * Gathering diagnostics on agent node. 54.183.97.70
 * Gathering diagnostics on agent node. 54.183.98.196
```

```
ls | grep .tar
clusterhq_flocker_logs_2e180842-938b-11e5-8dda-0649fef6c463.tar
clusterhq_flocker_logs_2eaf837a-938b-11e5-af5a-06c5b0d85831.tar
clusterhq_flocker_logs_30f5a448-938b-11e5-92a5-06fdbfd9dbb1.tar
```

Signed-off-by: Ryan Wallner ryan.wallner@clusterhq.com
