### PR TITLE
Run modprobe before zpool command on UbuntuOS

### DIFF
--- a/unofficial_flocker_tools/install.py
+++ b/unofficial_flocker_tools/install.py
@@ -109,6 +109,7 @@ add-apt-repository -y ppa:zfs-native/stable
 apt-get update
 apt-get -y --force-yes install libc6-dev zfsutils
 mkdir -p /var/opt/flocker
+modprobe zfs
 truncate --size 10G /var/opt/flocker/pool-vdev
 zpool create flocker /var/opt/flocker/pool-vdev
 """)


### PR DESCRIPTION
subprocess will return error when zfs module is not loaded after zfsutils package where installed. 
