### PR TITLE
use of.environ.get which will ignore empty strings

### DIFF
--- a/unofficial_flocker_tools/flocker_volumes.py
+++ b/unofficial_flocker_tools/flocker_volumes.py
@@ -350,11 +350,11 @@ def main(reactor, *argv):
         base = FlockerVolumesCommands()
         # Fake some commandline args based on env vars
         argv = list(argv)
-        if "FLOCKER_CERTS_PATH" in os.environ:
+        if os.environ.get("FLOCKER_CERTS_PATH"):
             argv = ["--certs-path", os.environ["FLOCKER_CERTS_PATH"]] + argv
-        if "FLOCKER_USER" in os.environ:
+        if os.environ.get("FLOCKER_USER"):
             argv = ["--user", os.environ["FLOCKER_USER"]] + argv
-        if "FLOCKER_CONTROL_SERVICE" in os.environ:
+        if os.environ.get("FLOCKER_CONTROL_SERVICE"):
             argv = ["--control-service", os.environ["FLOCKER_CONTROL_SERVICE"]] + argv
         base.parseOptions(argv)
         if base.subCommand is not None:


### PR DESCRIPTION
This fix means that empty environment variables will not be written as CLI arguments
