### PR TITLE
[FLOC-4348] Remove links to the UFT installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # Unofficial Flocker Tools
 
-This repository contains several ClusterHQ Labs projects.
+This repository contains the following ClusterHQ Labs projects.
 
-* [Installer](https://docs.clusterhq.com/en/latest/labs/installer.html)
-* [Volumes CLI](https://docs.clusterhq.com/en/latest/labs/volumes-cli.html)
-* [Volumes GUI](https://docs.clusterhq.com/en/latest/labs/volumes-gui.html)
+* [Flocker Volumes CLI (`flockerctl`)](https://docs.clusterhq.com/en/latest/flocker-features/flockerctl.html)
 
 ## Documentation
 
 Please refer to the individual projects above for instructions on how to use this repo.
-You may want to start with the installer docs.
 
 ## Running tests
 
@@ -20,3 +17,9 @@ $ trial test_integration.py
 ```
 
 Note the comment at the top of the `test_integration.py` file before running the test.
+
+
+## Changelog
+
+* 2016-07-27 Deprecated the "Labs Installer".
+  (also known as "hatch" / "uft-flocker-install")

--- a/go.sh
+++ b/go.sh
@@ -2,7 +2,7 @@
 do_install() {
 IMAGE="clusterhq/uft:latest"
 read -d '' DEPRECATION_WARNING <<EOF
-deprecated since Flocker 1.14.0 and will be removed in the next version of Flocker.
+deprecated in Flocker 1.14.0 and will be removed in the next version of Flocker.
 Use the official installation methods and tools instead.
 See https://docs.clusterhq.com.
 EOF
@@ -24,7 +24,7 @@ ${DEPRECATION_WARNING}
 END_WARNING
 
 if [ "\${DEPRECATED}" = "TRUE" ]; then
-    echo "WARNING: ${PREFIX}${CMD} is \${DEPRECATION_WARNING}" >&2
+    echo "WARNING: ${PREFIX}${CMD} was \${DEPRECATION_WARNING}" >&2
     echo "" >&2
 fi
 if docker version >/dev/null 2>&1; then
@@ -126,7 +126,7 @@ echo "Pulling Docker image for Flocker installer..."
 $SUDO_PREFIX docker pull $IMAGE
 if [ -n "${DEPRECATION_WARNING}" ]; then
     echo "" >&2
-    echo "WARNING: Some the commands are ${DEPRECATION_WARNING}" >&2
+    echo "WARNING: Some of these commands were ${DEPRECATION_WARNING}" >&2
 fi
 echo ""
 }

--- a/go.sh
+++ b/go.sh
@@ -2,7 +2,7 @@
 do_install() {
 IMAGE="clusterhq/uft:latest"
 read -d '' DEPRECATION_WARNING <<EOF
-deprecated in Flocker 1.14.0 and will be removed in the next version of Flocker.
+deprecated in Flocker 1.14.0 and will be removed in future versions of Flocker.
 Use the official installation methods and tools instead.
 See https://docs.clusterhq.com.
 EOF


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4348

Installation now shows the deprecated commands and a warning after installation.

```
(4478) (deprecate-labs-installer-FLOC-4348 =)[~/.../HybridLogic/unofficial-flocker-tools]$ sh ./go.sh 
[sudo] password for richard: 
Installed /usr/local/bin/flockerctl
Installed /usr/local/bin/uft-flocker-ca (deprecated)
Installed /usr/local/bin/uft-flocker-deploy (deprecated)
Installed /usr/local/bin/uft-flocker-config (deprecated)
Installed /usr/local/bin/uft-flocker-install (deprecated)
Installed /usr/local/bin/uft-flocker-plugin-install (deprecated)
Installed /usr/local/bin/uft-flocker-sample-files (deprecated)
Installed /usr/local/bin/uft-flocker-tutorial (deprecated)
Installed /usr/local/bin/uft-flocker-volumes (deprecated)
Installed /usr/local/bin/uft-flocker-get-nodes (deprecated)
Installed /usr/local/bin/uft-flocker-destroy-nodes (deprecated)
Installed /usr/local/bin/volume-hub-agents-install
Verifying internet connectivity inside container...
Pulling Docker image for Flocker installer...
Trying to pull repository docker.io/clusterhq/uft ... 
latest: Pulling from docker.io/clusterhq/uft
8387d9ff0016: Already exists 
3b52deaaf0ed: Already exists 
4bd501fad6de: Already exists 
a3ed95caeb02: Already exists 
b2417fb4bf25: Already exists 
2b599980924e: Already exists 
4c9fcc4f5358: Already exists 
Digest: sha256:683e7d46bd05da0f868d42fda1c0925a31afd83914e576d03e4ec1dabdc3eb27
Status: Image is up to date for docker.io/clusterhq/uft:latest

WARNING: Some of these commands were deprecated in Flocker 1.14.0 and will be removed in the next version of Flocker.
Use the official installation methods and tools instead.
See https://docs.clusterhq.com.
```

The deprecated commands also print a warning to stderr e.g.

```
(4478) (deprecate-labs-installer-FLOC-4348 =)[~/.../HybridLogic/unofficial-flocker-tools]$ uft-flocker-ca  initialize "foo"
WARNING: uft-flocker-ca was deprecated in Flocker 1.14.0 and will be removed in the next version of Flocker.
Use the official installation methods and tools instead.
See https://docs.clusterhq.com.

Created cluster.key and cluster.crt. Please keep cluster.key secret, as anyone who can access it will be able to control your cluster.

```

Test by installing the branch script:

`curl -sSL https://raw.githubusercontent.com/ClusterHQ/unofficial-flocker-tools/deprecate-labs-installer-FLOC-4348/go.sh | sh`

See also:
- https://github.com/ClusterHQ/flocker/pull/2873
