### PR TITLE
[FLOC-4538] Remove bash specific syntax from the installer and the installed script.

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 do_install() {
 IMAGE="clusterhq/uft:latest"
 read -d '' DEPRECATION_WARNING <<EOF
@@ -17,7 +17,7 @@ for CMD in flockerctl flocker-ca flocker-deploy flocker-config flocker-install f
         DEPRECATED="TRUE"
     fi
     cat <<EOF |sudo tee /usr/local/bin/${PREFIX}${CMD} >/dev/null
-#!/bin/sh
+#!/usr/bin/env bash
 DEPRECATED="${DEPRECATED}"
 read -d '' DEPRECATION_WARNING <<END_WARNING
 ${DEPRECATION_WARNING}

--- a/go.sh
+++ b/go.sh
@@ -1,11 +1,12 @@
-#!/usr/bin/env bash
+#!/bin/sh
 do_install() {
 IMAGE="clusterhq/uft:latest"
-read -d '' DEPRECATION_WARNING <<EOF
+DEPRECATION_WARNING=$(cat <<EOF
 deprecated in Flocker 1.14.0 and will be removed in future versions of Flocker.
 Use the official installation methods and tools instead.
 See https://docs.clusterhq.com.
 EOF
+)
 
 for CMD in flockerctl flocker-ca flocker-deploy flocker-config flocker-install flocker-plugin-install flocker-sample-files flocker-tutorial flocker-volumes flocker-get-nodes flocker-destroy-nodes volume-hub-agents-install; do
     if [ "$CMD" = "flockerctl" ] || [ "$CMD" = "volume-hub-agents-install" ]; then
@@ -17,12 +18,12 @@ for CMD in flockerctl flocker-ca flocker-deploy flocker-config flocker-install f
         DEPRECATED="TRUE"
     fi
     cat <<EOF |sudo tee /usr/local/bin/${PREFIX}${CMD} >/dev/null
-#!/usr/bin/env bash
+#!/bin/sh
 DEPRECATED="${DEPRECATED}"
-read -d '' DEPRECATION_WARNING <<END_WARNING
+DEPRECATION_WARNING=\$(cat <<END_WARNING
 ${DEPRECATION_WARNING}
 END_WARNING
-
+)
 if [ "\${DEPRECATED}" = "TRUE" ]; then
     echo "WARNING: ${PREFIX}${CMD} was \${DEPRECATION_WARNING}" >&2
     echo "" >&2


### PR DESCRIPTION
Fixes: https://clusterhq.atlassian.net/browse/FLOC-4538
Refs: https://github.com/ClusterHQ/unofficial-flocker-tools/issues/73

On Fedora 
```
$ ls -l /usr/bin/sh
lrwxrwxrwx 1 root root 4 Sep 30 09:25 /usr/bin/sh -> bash

```

But on Ubuntu 16.04:
```
$ ls -l /bin/sh
lrwxrwxrwx 1 root root 4 Feb 17  2016 /bin/sh -> dash

```

`read -d` is used in the installer and the installed script, but it's `bash` specific.

I caused this bug in https://github.com/ClusterHQ/unofficial-flocker-tools/pull/72/files 🙁 